### PR TITLE
Add _layouts to enable kramdown latex formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Gemfile*
+_site

--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,5 @@
 theme: jekyll-theme-architect
+markdown: kramdown
 
+kramdown:
+     input: GFM

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,12 @@
+---
+layout: default
+---
+<article class="post">
+
+  <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
+
+  <div class="post-content" itemprop="articleBody">
+    {{ content }}
+  </div>
+
+</article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,12 @@
+---
+layout: default
+---
+<article class="post">
+
+  <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
+
+  <div class="post-content" itemprop="articleBody">
+    {{ content }}
+  </div>
+
+</article>

--- a/_posts/2017-02-26-Lesson01-Neurons.md
+++ b/_posts/2017-02-26-Lesson01-Neurons.md
@@ -1,3 +1,9 @@
+$$
+2+2
+$$
+
+The network turns $$[i_0,i_1,\cdots,i_n]$$ into $$[o_0,o_1,\cdots,o_n]$$!
+
 # Lesson 01 - Neurons
 ## AKA - "What the frickity frackity hickity heckity is a neuron?"
 

--- a/index.md
+++ b/index.md
@@ -1,4 +1,3 @@
-
 # Machine Learning for humans
 
 Over the course of a few months, I've been researching the concepts and principles of machine learning. I've been researching neurons, backpropagation, classification, cross entropy, all of it. To a lot of people, including me a few months ago, all of this seems daunting, and insanely complex.


### PR DESCRIPTION
The kramdown markdown processor now given in `_config.yaml` renders all special escaped math statements with a latex compiler. The rendered math equations are even copiable, and they can be shown inline or as special paragraph blocks.

The two new files:
- `_layouts/`
  - `page.html`
  - `post.html`

each include a link to `cdn.mathjax.org/mathjax/latest/MathJax.js` that allows kramdown to handle all math between  `$$` and `$$` begin and end tags. The `post.html` is needed for posts, but `page.html` so far is needed only for the index.

This code in [_posts/2017-02-26-Lesson01-Neurons.md ][1]
```
$$
2+2
$$

The network turns $$[i_0,i_1,\cdots,i_n]$$ into $$[o_0,o_1,\cdots,o_n]$$!
```

Becomes this: ![hi][0]

[0]: http://img.hoff.in/learn-blog/mathjax.png
[1]: https://github.com/ironman5366/learn-blog/compare/master...math#diff-31877d8ee2166fc87bbfab5121fb8f54