### PR TITLE
Add author information!

### DIFF
--- a/_data/_authors.yml
+++ b/_data/_authors.yml
@@ -5,7 +5,7 @@ default:
 beddow:
   name: Will Beddow
   display_name: Will
-  gravatar: '00000000000000000000000000000000'
+  gravatar: b45f0b6885bef80856ded628de522b19 
   email: will.beddow@gmail.com
   web: http://willbeddow.com
   gravatar: default.gravatar

--- a/_data/_authors.yml
+++ b/_data/_authors.yml
@@ -1,0 +1,20 @@
+default:
+  name: Learn Blog Staff
+  gravatar: '00000000000000000000000000000000'
+  web: https://ironman5366.github.io/learn-blog
+beddow:
+  name: Will Beddow
+  display_name: Will
+  gravatar: '00000000000000000000000000000000'
+  email: will.beddow@gmail.com
+  web: http://willbeddow.com
+  gravatar: default.gravatar
+  github: ironman5366
+hoffer:
+  name: John Hoffer
+  display_name: John
+  email: john@hoff.in
+  gravatar: b59fffe27485b55695887a7cc35c400f
+  web: http://via.hoff.in
+  twitter: thejohnhoffer
+  github: thejohnhoffer

--- a/_includes/add_name.html
+++ b/_includes/add_name.html
@@ -1,0 +1,10 @@
+{% assign author = site.data._authors['default'] %}
+{% if site.data._authors contains include.name %}
+    {% assign author = site.data._authors[include.name] %}
+{% endif %}
+{% assign g_root = 'https://www.gravatar.com/avatar/' %}
+{% assign gravatar = g_root | append: author.gravatar %}
+<a href="{{ author.web }}" target="_blank">
+  <img src= "{{ gravatar }}" height=32 width=32></img>
+  {{ author.name }}
+</a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,6 +6,23 @@ layout: default
   <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
 
   <div class="post-content" itemprop="articleBody">
+    <div>
+      <span>By </span>
+      {% assign authorCount = page.authors | size %}
+      {% if authorCount == 0 %}
+          {% include add_name.html name='default' %}
+      {% else %}
+          {% for name in page.authors %}
+              {% if forloop.first %}
+                  {% include add_name.html name=name %}
+              {% elsif forloop.last %}
+                  and {% include add_name.html name=name %}
+              {% else %}
+                  , {% include add_name.html name=name %}
+              {% endif %}
+          {% endfor %}
+      {% endif %}
+    </div>
     {{ content }}
   </div>
 

--- a/_posts/2017-02-26-Lesson01-Neurons.md
+++ b/_posts/2017-02-26-Lesson01-Neurons.md
@@ -1,3 +1,8 @@
+---
+authors:
+   - hoffer
+   - beddow
+---
 # Lesson 01 - Neurons
 ## AKA - "What the frickity frackity hickity heckity is a neuron?"
 


### PR DESCRIPTION
At the top of each new post,
```
---
authors:
   - hoffer
   - beddow
---
# Lesson 01 - Neurons
```
becomes
![an image with the authors defined above][0]

[0]: http://img.hoff.in/learn-blog/authors.png

Will, your `gravatar` in `_data/_authors.yml` is currently set to:
`b45f0b6885bef80856ded628de522b19`

This makes a request to 
`https://s.gravatar.com/avatar/b45f0b6885bef80856ded628de522b19`

Since this string is an MD5 hash for will.beddow@gmail.com, that link will point to any avatar you associate with will.beddow@gmail.com through gravatar.

[Add a gravatar here][1]

Interestingly, we can use a jekyll plugin to make an md5 hash of any email so that new authors (if we get any) won't need to manually update that md5 hash as long as `_data/_authors.yml` contains the right email address. It seems quite excessive, but I'll look into doing that if it isn't too hard.

[1]: https://en.gravatar.com/connect/?source=_signup